### PR TITLE
Solve some obvious problems.

### DIFF
--- a/Umbra Spherae/history/titles/d_samarkand.txt
+++ b/Umbra Spherae/history/titles/d_samarkand.txt
@@ -1,0 +1,19 @@
+1137.1.1={
+	liege=0 # Kara Khitan expansion
+	holder = 1000202528 # Yelü-Dashi
+}
+1143.1.1={
+	holder = 1000202529 # Yelü-Yilie
+}
+1163.1.1={
+	holder = 1000202530 # Pusuwan
+}
+1177.1.1={
+	holder = 1000202531 # Yelü-Zhilugu
+}
+1211.1.1={
+	holder = 188914 # Kuchlug (de facto)
+}
+1218.1.1={
+	holder=0
+}

--- a/Umbra Spherae/localisation/0_US_provinces_pinyin.csv
+++ b/Umbra Spherae/localisation/0_US_provinces_pinyin.csv
@@ -440,38 +440,38 @@ PROV1902;Cuad-neng;Cuad-neng;Cuad-neng;Cuad-neng;Cuad-neng;Cuad-neng;Cuad-neng;C
 PROV1903;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;Siuh-sren;x
 PROV1904;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;Yengx-chjang;x
 PROV1905;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;Dong-driung;x
-PROV1906;Leng;Leng;Leng;Leng;Leng;Leng;Leng;Leng;Leng;Leng;Leng;Leng;Leng;x
-PROV1907;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;Yoi;x
-PROV1908;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;Ghrax;x
-PROV1909;Jem;Jem;Jem;Jem;Jem;Jem;Jem;Jem;Jem;Jem;Jem;Jem;Jem;x
-PROV1910;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;Iuh;x
-PROV1911;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;Ngin;x
+PROV1906;Ling;Ling;Ling;Ling;Ling;Ling;Ling;Ling;Ling;Ling;Ling;Ling;Ling;x
+PROV1907;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;x
+PROV1908;Xia;Xia;Xia;Xia;Xia;Xia;Xia;Xia;Xia;Xia;Xia;Xia;Xia;x
+PROV1909;Yan;Yan;Yan;Yan;Yan;Yan;Yan;Yan;Yan;Yan;Yan;Yan;Yan;x
+PROV1910;You;You;You;You;You;You;You;You;You;You;You;You;You;x
+PROV1911;Yin;Yin;Yin;Yin;Yin;Yin;Yin;Yin;Yin;Yin;Yin;Yin;Yin;x
 PROV1912;Liang;Liang;Liang;Liang;Liang;Liang;Liang;Liang;Liang;Liang;Liang;Liang;Liang;x
-PROV1913;Kam;Kam;Kam;Kam;Kam;Kam;Kam;Kam;Kam;Kam;Kam;Kam;Kam;x
+PROV1913;Gan;Gan;Gan;Gan;Gan;Gan;Gan;Gan;Gan;Gan;Gan;Gan;Gan;x
 PROV1914;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;Eji Nai;x
 PROV1915;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;Brak-mra;x
 PROV1916;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;Hok-sren;x
 PROV1917;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;Iux-siang;x
-PROV1918; 'y; 'y; 'y; 'y; 'y; 'y; 'y; 'y; 'y; 'y; 'y; 'y; 'y;x
-PROV1919;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;Bjen;x
-PROV1920;Keh;Keh;Keh;Keh;Keh;Keh;Keh;Keh;Keh;Keh;Keh;Keh;Keh;x
+PROV1918;You;You;You;You;You;You;You;You;You;You;You;You;You;x
+PROV1919;Ping;Ping;Ping;Ping;Ping;Ping;Ping;Ping;Ping;Ping;Ping;Ping;Ping;x
+PROV1920;Ji;Ji;Ji;Ji;Ji;Ji;Ji;Ji;Ji;Ji;Ji;Ji;Ji;x
 PROV1921;Dan;Dan;Dan;Dan;Dan;Dan;Dan;Dan;Dan;Dan;Dan;Dan;Dan;x
-PROV1922;Kye;Kye;Kye;Kye;Kye;Kye;Kye;Kye;Kye;Kye;Kye;Kye;Kye;x
-PROV1923;Jek;Jek;Jek;Jek;Jek;Jek;Jek;Jek;Jek;Jek;Jek;Jek;Jek;x
-PROV1924;Yon;Yon;Yon;Yon;Yon;Yon;Yon;Yon;Yon;Yon;Yon;Yon;Yon;x
-PROV1925;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;Sruk;x
-PROV1926; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh; 'ingh;x
-PROV1927; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih; 'yoih;x
-PROV1928;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;Dad-dengh;x
-PROV1929;Prah;Prah;Prah;Prah;Prah;Prah;Prah;Prah;Prah;Prah;Prah;Prah;Prah;x
-PROV1930;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;Kimx;x
-PROV1931;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;Cuung;x
-PROV1932;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;Ghrem;x
-PROV1933; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih; 'iih;x
-PROV1934;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;Leu-jang;x
-PROV1935;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;Chjimx;x
-PROV1936;Henx;Henx;Henx;Henx;Henx;Henx;Henx;Henx;Henx;Henx;Henx;Henx;Henx;x
-PROV1937;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;Biuk;x
+PROV1922;Gui;Gui;Gui;Gui;Gui;Gui;Gui;Gui;Gui;Gui;Gui;Gui;Gui;x
+PROV1923;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;x
+PROV1924;Yun;Yun;Yun;Yun;Yun;Yun;Yun;Yun;Yun;Yun;Yun;Yun;Yun;x
+PROV1925;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;Shuo;x
+PROV1926;Ying;Ying;Ying;Ying;Ying;Ying;Ying;Ying;Ying;Ying;Ying;Ying;Ying;x
+PROV1927;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;Wei;x
+PROV1928;Dading;Dading;Dading;Dading;Dading;Dading;Dading;Dading;Dading;Dading;Dading;Dading;Dading;x
+PROV1929;Ba;Ba;Ba;Ba;Ba;Ba;Ba;Ba;Ba;Ba;Ba;Ba;Ba;x
+PROV1930;Jin;Jin;Jin;Jin;Jin;Jin;Jin;Jin;Jin;Jin;Jin;Jin;Jin;x
+PROV1931;Zong;Zong;Zong;Zong;Zong;Zong;Zong;Zong;Zong;Zong;Zong;Zong;Zong;x
+PROV1932;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;x
+PROV1933;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;Yi;x
+PROV1934;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;Liaoyang;x
+PROV1935;Shen;Shen;Shen;Shen;Shen;Shen;Shen;Shen;Shen;Shen;Shen;Shen;Shen;x
+PROV1936;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;Xian;x
+PROV1937;Fu;Fu;Fu;Fu;Fu;Fu;Fu;Fu;Fu;Fu;Fu;Fu;Fu;x
 PROV1938;Manju;Manju;Manju;Manju;Manju;Manju;Manju;Manju;Manju;Manju;Manju;Manju;Manju;x
 PROV1939;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;Phiung;x
 PROV1940;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;Sjingh;x
@@ -496,7 +496,7 @@ PROV1958;Qarqan;Qarqan;Qarqan;Qarqan;Qarqan;Qarqan;Qarqan;Qarqan;Qarqan;Qarqan;Q
 PROV1959;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;Balasagun;x
 PROV1960;Talas;Talas;Talas;Talas;Talas;Talas;Talas;Talas;Talas;Talas;Talas;Talas;Talas;x
 PROV1961;Sra;Sra;Sra;Sra;Sra;Sra;Sra;Sra;Sra;Sra;Sra;Sra;Sra;x
-PROV1962;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;Siuk;x
+PROV1962;Su;Su;Su;Su;Su;Su;Su;Su;Su;Su;Su;Su;Su;x
 PROV1963;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;Uzgen;x
 PROV1964;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;Almalik;x
 PROV1965;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;Kuldja;x


### PR DESCRIPTION
Before we have an idea on China, let's solve some obvious problems. 
1. Some provinces in China empire still use middle chinese in pinyin localisation file.
2. Because of Horse Lords, there are duplicated characters:
    All characters of Kara-Khitan family are in fact in Yelu family.
    Many mongolian characters have two copies, which makes their titles messy.
